### PR TITLE
Update GetTaxi.form regex on money and taxiCost fields

### DIFF
--- a/src/main/resources/static/forms/GetTaxi.form
+++ b/src/main/resources/static/forms/GetTaxi.form
@@ -7,7 +7,7 @@
       "type": "textfield",
       "validate": {
         "required": true,
-        "pattern": "^(?:0|[1-9][0-9]*)\\.[0-9]+$"
+        "pattern": "^(?:0|[1-9][0-9]*)\.[0-9]+$"
       },
       "description": "How much cash do you want to bring?"
     },
@@ -26,7 +26,7 @@
       "label": "Enter the price of the taxi",
       "type": "textfield",
       "validate": {
-        "pattern": "^(?:0|[1-9][0-9]*)\\.[0-9]+$"
+        "pattern": "^(?:0|[1-9][0-9]*)\.[0-9]+$"
       },
       "description": "for tax purposes"
     }


### PR DESCRIPTION
I fixed the bug produced by an extra backslash in the regex of the fields money and taxiCost.